### PR TITLE
Add app permission middleware and prefix support

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Singkat\Controller;
+use App\Models\ManManagement\Pegawai;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -68,7 +69,8 @@ class LoginController extends Controller
         $userInfo = $userInfoResponse->json();
         // dd($userInfo);
 
-        $user = User::where('pegawai_id', $userInfo['nip-lama'])->first();
+        // $user = User::where('pegawai_id', $userInfo['nip-lama'])->first();
+        $user = Pegawai::where('nip_lama', $userInfo['nip-lama'])->first();
         if ($user) {
             Auth::login($user);
             $request->session()->regenerate();

--- a/app/Http/Controllers/ManManagement/AppController.php
+++ b/app/Http/Controllers/ManManagement/AppController.php
@@ -42,6 +42,7 @@ class AppController extends Controller
         $validated = $request->validate([
             'id' => ['sometimes', 'nullable'],
             'label' => ['required', 'string', 'max:30'],
+            'prefix' => ['required', 'string', 'max:30'],
             'deskripsi' => ['required', 'string', 'max:100'],
             'route_link' => ['required', 'string', 'max:100'],
             'navigation' => ['required', 'string', 'max:30'],

--- a/app/Http/Middleware/AppPermission.php
+++ b/app/Http/Middleware/AppPermission.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\ManManagement\AnggotaTimKerja;
+use App\Models\ManManagement\AppManagement;
+use App\Models\ManManagement\Role;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Route;
+use Symfony\Component\HttpFoundation\Response;
+
+class AppPermission
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $prefix = Route::current()->getPrefix();
+        $user = Auth::user();
+        $app = AppManagement::where('prefix', $prefix)->first();
+        if (!$app) abort(403, 'Aplikasi tidak ditemukan');
+        $roles_on_app = Role::where('app_id', $app->id)->get();
+        $isPermissable = false;
+
+        $all = $roles_on_app->where('type', 'all')->first();
+        if ($all) $isPermissable = true;
+
+        $keanggotaan = AnggotaTimKerja::where('pegawai_id', $user->id)->pluck('tim_id')->toArray();
+        $tim = $roles_on_app->where('type', 'tim')->whereIn('to_role_id', $keanggotaan);
+        if ($tim->isNotEmpty()) $isPermissable = true;
+
+        $unit = $roles_on_app->where('type', 'unit')->where('to_role_id', $user->id)->first();
+        if ($unit) $isPermissable = true;
+
+        if ($isPermissable)
+            return $next($request);
+
+        abort(403, 'Anda tidak memiliki hak akses aplikasi ini');
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -3,6 +3,7 @@
 namespace App\Http\Middleware;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
 use Inertia\Middleware;
 
@@ -34,7 +35,7 @@ class HandleInertiaRequests extends Middleware
         return [
             ...parent::share($request),
             'auth' => [
-                'user' => $request->user(),
+                'user' => Auth::user(),
             ],
             'route' => $route,
             "flash" => [

--- a/app/Http/Middleware/RoleCheck.php
+++ b/app/Http/Middleware/RoleCheck.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class RoleCheck
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        return $next($request);
+    }
+}

--- a/app/Models/ManManagement/AppManagement.php
+++ b/app/Models/ManManagement/AppManagement.php
@@ -12,6 +12,7 @@ class AppManagement extends Model
     public $timestamps = true;
     protected $fillable = [
         'label',
+        'prefix',
         'deskripsi',
         'route_link',
         'navigation',

--- a/app/Models/ManManagement/Pegawai.php
+++ b/app/Models/ManManagement/Pegawai.php
@@ -2,10 +2,12 @@
 
 namespace App\Models\ManManagement;
 
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Notifications\Notifiable;
 
-class Pegawai extends Model
+class Pegawai extends User
 {
+    use Notifiable;
     //
     protected $connection = 'sulutweb_man_management';
     protected $table = 'pegawai';

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\AppPermission;
 use App\Http\Middleware\UseVueInertia;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
@@ -19,6 +20,7 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
         $middleware->alias([
             'use.vue.inertia' => UseVueInertia::class,
+            'permission' => AppPermission::class,
         ]);
 
         //

--- a/config/auth.php
+++ b/config/auth.php
@@ -66,7 +66,8 @@ return [
     'providers' => [
         'users' => [
             'driver' => 'eloquent',
-            'model' => env('AUTH_MODEL', App\Models\User::class),
+            // 'model' => env('AUTH_MODEL', App\Models\User::class),
+            'model' => env('AUTH_MODEL', App\Models\ManManagement\Pegawai::class),
         ],
 
         // 'users' => [

--- a/database/migrations/2026_04_29_023212_add_prefix_to_appmanagement.php
+++ b/database/migrations/2026_04_29_023212_add_prefix_to_appmanagement.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    protected $connection = 'sulutweb_man_management';
+    public function up(): void
+    {
+        Schema::table('application_management', function (Blueprint $table) {
+            //
+            $table->string('prefix', 30)->after('label')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('application_management', function (Blueprint $table) {
+            //
+            $table->dropColumn('prefix');
+        });
+    }
+};

--- a/resources/js/Pages/Landing/Content/index.jsx
+++ b/resources/js/Pages/Landing/Content/index.jsx
@@ -2,40 +2,6 @@ import Card from "@/Components/Card";
 import { usePage } from "@inertiajs/react";
 const Content = () => {
     const page = usePage()
-    const daftarAplikasi = [
-        {
-            imagePath: route('index'),
-            name: <span className="text-nowrap">SINGKAT</span>,
-            description: "Pengelolaan Angka Kredit dan Analisis Beban Kerja",
-            link: route("singkat"),
-            navMode: 'react',
-            isMaintenance: true,
-            maintenanceMessage: "Aplikasi sedang dalam pemeliharaan"
-        },
-        {
-            imagePath: route('index') + "/images/logo/MeetSulut-Zoom-Logo.png",
-            name: <span className="text-nowrap">MeetSulut</span>,
-            description: "Pengajuan dan Pengelolaan Zoom",
-            link: route("meeting.dashboard"),
-            navMode: 'reload',
-        },
-        {
-            imagePath: route('index') + "/images/logo/Simple-Logo.png",
-            name: <span className="text-nowrap">SIMPLE</span>,
-            description: "Pengajuan dan Pengelolaan Lembur",
-            link: route("singkat"),
-            navMode: 'reload',
-            isMaintenance: true,
-            maintenanceMessage: "Aplikasi sedang dalam proses migrasi"
-        },
-        {
-            imagePath: route('index') + "/images/logo/Man-Management-Logo.png",
-            name: <span className="text-nowrap">MANMENT</span>,
-            description: "Pengelolaan Pegawai dalam Aplikasi",
-            link: route("man-management.index"),
-            navMode: 'reload',
-        },
-    ];
     return (
         <div className="mt-16">
 

--- a/resources/js/Pages/Landing/index.jsx
+++ b/resources/js/Pages/Landing/index.jsx
@@ -1,6 +1,6 @@
 import CardDataStats from "@/Components/CardDataStats";
 import AuthenticatedLayout from "@/Layouts/AuthenticatedLayout";
-import { Head } from "@inertiajs/react";
+import { Head, usePage } from "@inertiajs/react";
 
 import React, { useEffect } from "react";
 import axios from "axios";
@@ -8,23 +8,10 @@ import axios from "axios";
 import LandingLayout from "@/Layouts/LandingLayout";
 import Content from "./Content";
 
-export default function index({ auth, jumlahPegawai, users, unitKerja }) {
-    useEffect(() => {
-        const fetchData = async () => {
-            try {
-                const response = await axios.get("/api/abk-summary");
-                setChartData(response.data);
-            } catch (error) {
-                console.error("Error fetching data: ", error);
-            }
-        };
-
-        fetchData();
-    }, []);
+export default function index({ auth }) {
     return (
         <LandingLayout user={auth.user}>
             <Head title="Dashboard" />
-
             <Content />
         </LandingLayout>
     );

--- a/resources/js/Pages/ManManagement/Aplikasi.vue
+++ b/resources/js/Pages/ManManagement/Aplikasi.vue
@@ -37,6 +37,7 @@
         class="w-full"
         lazy
         paginator
+        scrollable
         :rows="apps.per_page"
         :first="(apps.current_page - 1) * apps.per_page"
         :total-records="apps.total"
@@ -49,7 +50,13 @@
         paginator-template="FirstPageLink PrevPageLink PageLinks NextPageLink LastPageLink CurrentPageReport RowsPerPageDropdown"
         current-page-report-template="Menampilkan {first} s.d {last} dari {totalRecords} data"
       >
-        <Column header="Nama Aplikasi" field="label" sortable>
+        <Column
+          frozen
+          class="min-w-[150px]"
+          header="Nama Aplikasi"
+          field="label"
+          sortable
+        >
           <template #body="{ data }">
             <div class="flex items-center gap-2">
               <img style="width: 32px" :src="'/storage/' + data.image_path" />
@@ -57,7 +64,8 @@
             </div>
           </template>
         </Column>
-        <Column header="Deskripsi" field="deskripsi" sortable />
+        <Column header="Prefix" field="prefix" />
+        <Column class="min-w-[300px]" header="Deskripsi" field="deskripsi" sortable />
         <Column header="Link Aplikasi" field="route_link" sortable>
           <template #body="{ data }">
             <Badge
@@ -83,8 +91,18 @@
             ></Badge>
           </template>
         </Column>
-        <Column header="Message" field="maintenance_message" sortable />
-        <Column :exportable="false">
+        <Column
+          class="min-w-[300px]"
+          header="Message"
+          field="maintenance_message"
+          sortable
+        />
+        <Column align-frozen="right" frozen :exportable="false">
+          <template #header>
+            <div class="flex justify-center w-full">
+              <span class="font-bold">Edit</span>
+            </div>
+          </template>
           <template #body="slotProps">
             <div class="flex justify-end gap-2 w-full">
               <Button

--- a/resources/views/errors/503.blade.php
+++ b/resources/views/errors/503.blade.php
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sistem dalam Perbaikan | SulutWeb</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-slate-50 flex items-center justify-center min-h-screen p-4 font-sans text-slate-800">
+    
+    <div class="max-w-lg w-full bg-white p-8 md:p-12 rounded-2xl shadow-xl text-center border border-slate-100">
+        <div class="flex justify-center mb-6">
+            <svg class="w-24 h-24 text-indigo-500 animate-[spin_4s_linear_infinite]" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path>
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
+            </svg>
+        </div>
+
+        <h1 class="text-3xl font-bold text-slate-900 mb-3 tracking-tight">Kami Sedang Melakukan Pemeliharaan</h1>
+        <p class="text-slate-500 mb-8 leading-relaxed">
+            Mohon maaf atas ketidaknyamanan ini. Kami sedang melakukan pembaruan sistem untuk meningkatkan pengalaman Anda. Silakan coba kembali dalam beberapa saat.
+        </p>
+
+        <div class="inline-flex items-center gap-2 px-4 py-2 bg-indigo-50 text-indigo-700 font-medium rounded-full text-sm">
+            <span class="relative flex h-3 w-3">
+              <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-indigo-400 opacity-75"></span>
+              <span class="relative inline-flex rounded-full h-3 w-3 bg-indigo-500"></span>
+            </span>
+            Sistem Akan Segera Kembali
+        </div>
+    </div>
+
+</body>
+</html>

--- a/routes/meeting.php
+++ b/routes/meeting.php
@@ -3,7 +3,7 @@
 use App\Http\Controllers\Meeting\ZoomController;
 use Illuminate\Support\Facades\Route;
 
-Route::prefix('meeting')->name('meeting.')->middleware(['auth', 'use.vue.inertia'])->group(function () {
+Route::prefix('meeting')->name('meeting.')->middleware(['auth', 'use.vue.inertia', 'permission'])->group(function () {
     Route::get('/', [ZoomController::class, 'dashboard'])->name('home');
     Route::get('/dashboard', [ZoomController::class, 'dashboard'])->name('dashboard');
     Route::get('/index/{id?}', [ZoomController::class, 'index'])->name('index');

--- a/routes/mmanagement.php
+++ b/routes/mmanagement.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Response;
 use Illuminate\Support\Facades\Route;
 use Maatwebsite\Excel\Facades\Excel;
 
-Route::prefix('man-management')->name('man-management.')->middleware(['auth', 'use.vue.inertia'])->group(function () {
+Route::prefix('man-management')->name('man-management.')->middleware(['auth', 'use.vue.inertia', 'permission'])->group(function () {
     Route::get('/', [HomeController::class, 'index']);
     Route::get('/index', [HomeController::class, 'index'])->name('index');
 


### PR DESCRIPTION
Introduce app-level permission checks and application prefix support. Adds AppPermission and RoleCheck middleware, registers a 'permission' alias in bootstrap/app.php, and applies the middleware to meeting and man-management routes to enforce access by app prefix and roles. Adds a migration to add a nullable 'prefix' column to application_management and updates AppManagement model and controller validation to include the prefix field. Integrates ManManagement Pegawai with the authentication system (auth provider switched to Pegawai, Pegawai now extends User and LoginController resolves users via Pegawai::where('nip_lama', ...)). Update Inertia shared auth user to use Auth::user(), adjust ManManagement Aplikasi UI to show prefix and improve table layout, remove hardcoded app list from landing content, and add a 503 maintenance view.